### PR TITLE
Fixes undefined usernames in Slack's IRC gateway

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -596,7 +596,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     if (self.opt.secure) {
         var creds = self.opt.secure;
         if (typeof self.opt.secure !== 'object') {
-            creds = {};
+            creds = { rejectUnauthorized: !self.opt.secure };
         }
 
         self.conn = tls.connect(self.opt.port, self.opt.server, creds, function() {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -880,7 +880,7 @@ function parseMessage(line, stripColors) { // {{{
     if ( match = line.match(/^:([^ ]+) +/) ) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        if ( match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
+        if ( match = message.prefix.match(/^([._a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
             message.nick = match[1];
             message.user = match[3];
             message.host = match[4];


### PR DESCRIPTION
Slack users can have dots in their usernames and raw messages look something
like this:

```
:dave.test!dave.test@irc.tinyspeck.com PRIVMSG #hubottest :testing
```

This patch adds the dot to the message prefix matching to properly parse out the
username.  Undefined usernames can cause all sorts of problems with Hubot
recognizing commands.
